### PR TITLE
Parse CDATA in `<system-out>` bodies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,12 +730,16 @@ fn parse_system<B: BufRead>(
     r: &mut XMLReader<B>,
 ) -> Result<Option<String>, Error> {
     let mut buf = Vec::new();
-    let mut res = None;
+    let mut res: Option<String> = None;
     loop {
         match r.read_event_into(&mut buf) {
             Ok(XMLEvent::End(ref e)) if e.name() == orig.name() => break,
             Ok(XMLEvent::Text(e)) => {
-                res = Some(e.unescape()?.to_string());
+                res.get_or_insert(String::new()).push_str(&e.unescape()?);
+            }
+            Ok(XMLEvent::CData(e)) => {
+                res.get_or_insert(String::new())
+                    .push_str(str::from_utf8(&e)?);
             }
             Ok(XMLEvent::Eof) => {
                 return Err(Error::UnexpectedEndOfFile(format!("{:?}", orig.name())));


### PR DESCRIPTION
Hi, here's a PR that adds support for `<system-out>` tags containing XML [`<![CDATA[...]]>`](https://en.wikipedia.org/wiki/CDATA) strings.

My use-case is that Bazel outputs `<system-out>` with `<CDATA>` tags rather than plain text. Only UTF-8 data is supported, but I think this is a requirement of the rest of your library too.

P.S. thanks for working on this library, it's very useful!