### PR TITLE
ci: add weekly cargo-audit workflow

### DIFF
--- a/.github/scripts/audit-issues.bash
+++ b/.github/scripts/audit-issues.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Open a GitHub issue per RustSec advisory found in a `cargo audit --json` report.
+# Requires: gh (authenticated via $GH_TOKEN), jq, and $RUN_URL in the environment.
+set -euo pipefail
+
+report=${1:-audit.json}
+
+jq -c '.vulnerabilities.list // [] | .[]' "$report" | while read -r item; do
+    id=$(jq -r '.advisory.id' <<<"$item")
+    title=$(jq -r '.advisory.title' <<<"$item")
+    pkg=$(jq -r '.package.name' <<<"$item")
+    version=$(jq -r '.package.version' <<<"$item")
+    url=$(jq -r '.advisory.url // ""' <<<"$item")
+    desc=$(jq -r '.advisory.description' <<<"$item")
+    patched=$(jq -r '.versions.patched // [] | join(", ")' <<<"$item")
+    unaffected=$(jq -r '.versions.unaffected // [] | join(", ")' <<<"$item")
+
+    # Dedup: skip if an open issue already references this advisory id.
+    if [ -n "$(gh issue list --state open --search "$id in:title" --json number --jq '.[0].number // empty')" ]; then
+        echo "issue for $id already open, skipping"
+        continue
+    fi
+
+    body=$(printf '| Details |  |\n| --- | --- |\n| Package | `%s` |\n| Version | `%s` |\n| URL | %s |\n| Patched Versions | %s |\n| Unaffected Versions | %s |\n\n%s\n\n_Reported by `cargo audit` in [this run](%s)._\n' \
+        "$pkg" "$version" "$url" "$patched" "$unaffected" "$desc" "$RUN_URL")
+
+    gh issue create --title "$id: $title" --body "$body"
+done

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,42 @@
+---
+name: audit
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - .github/workflows/audit.yml
+      - .github/scripts/ci.bash
+      - .github/scripts/audit-issues.bash
+  schedule:
+    - cron: '0 16 * * 3'  # every Wednesday at 18:00 Paris time (CEST/UTC+2)
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+      - name: install rust
+        run: curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+      - name: install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: run audit
+        id: audit
+        run: cargo audit --json | tee audit.json
+        continue-on-error: true
+      - name: open issues for advisories
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: .github/scripts/audit-issues.bash audit.json
+      - name: fail if advisories found
+        if: steps.audit.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Runs cargo audit weekly on Wednesday at 18:00 Paris time, on relevant pushes to main, and via workflow_dispatch. Opens a deduplicated GitHub issue per RustSec advisory found.